### PR TITLE
Zig tests

### DIFF
--- a/ob-zig-test.org
+++ b/ob-zig-test.org
@@ -30,6 +30,58 @@
   try stdout.print("{s} {d}", .{q, q.len});
 #+end_src
 
+* Tests zig tests
+:PROPERTIES: 
+:ID:       b1d3335f-8731-43b8-9246-6e613f3be3a2
+:END:
+#+source: simple_zig_test
+#+begin_src zig :imports '(std) :testsuite 'yes :results silent 
+  test "simple test" {
+    const stdout = std.io.getStdOut().writer();
+    const hello = "hello";
+
+    try std.testing.expectEqual("hello", hello);
+    try stdout.print("{s}", .{hello});
+  }
+#+end_src
+
+#+source: fn_zig_test
+#+begin_src zig :imports '(std) :testsuite 'yes :results silent 
+  fn helloFn() []const u8 {
+      return "hello";
+  }
+
+  test "fn test" {
+      const stdout = std.io.getStdOut().writer();
+      var hello = helloFn();
+
+      try std.testing.expectEqualStrings("hello", hello);
+      try stdout.print("{s}", .{hello});
+  }
+#+end_src
+
+#+source: multi_tests_zig_test
+#+begin_src zig :imports '(std) :testsuite 'yes :results silent 
+  fn helloFn() []const u8 {
+      return "hello";
+  }
+
+  test "fn test" {
+      const stdout = std.io.getStdOut().writer();
+      var hello = helloFn();
+
+      try std.testing.expectEqualStrings("hello", hello);
+      try stdout.print("{s}", .{hello});
+  }
+
+  test "simple test" {
+    const stdout = std.io.getStdOut().writer();
+    var hello = "hello";
+
+    try std.testing.expectEqual("hello", hello);
+    try stdout.print("{s}", .{hello});
+  }
+#+end_src
 
 * List var
 :PROPERTIES:

--- a/ob-zig.el
+++ b/ob-zig.el
@@ -91,6 +91,7 @@ its header arguments."
   (let ((vars (org-babel--get-vars params))
 	(colnames (cdr (assq :colname-names params)))
 	(main-p (not (string= (cdr (assq :main params)) "no")))
+	(testsuite (string= (cdr (assq :testsuite params)) "yes"))
         (imports (org-babel-read
                   (cdr (assq :imports params))
                   nil))
@@ -160,7 +161,7 @@ its header arguments."
                                     (type-descriptor (org-babel-zig-val-type-descriptor tbl)))
                                (org-babel-zig-header-to-zig head type-descriptor))) colnames "\n")
 		;; body
-		(if main-p
+		(if (and main-p (not testsuite))
 		    (org-babel-zig-ensure-main-wrap body)
 		  body) "\n") "\n")))
 
@@ -205,6 +206,7 @@ This function is called by `org-babel-execute-src-block'"
          ;; expand the body with `org-babel-expand-body:zig'
          (tmp-src-file (org-babel-temp-file
 			"Zig-src-" ".zig"))
+        (testsuite (string= (cdr (assq :testsuite params)) "yes"))
 	 ;; (tmp-bin-file
 	 ;;  (org-babel-process-file-name
 	 ;;   (org-babel-temp-file "Zig-bin-" org-babel-exeext)))
@@ -221,9 +223,11 @@ This function is called by `org-babel-execute-src-block'"
 			  (if (listp libs) libs (list libs))
 			  " "))
          (full-body (org-babel-expand-body:zig
-                     body params processed-params))
-         (full-command (format "%s run %s"
+                     body params processed-params ))
+         (zig-execute-command (if testsuite "test" "run"))
+         (full-command (format "%s %s %s"
                                org-babel-zig-compiler
+                               zig-execute-command
                                (org-babel-process-file-name tmp-src-file))))
     ;; (message "BODY: %s" full-body)
     ;; (message "CMD: %s" full-command)

--- a/ob-zig.el
+++ b/ob-zig.el
@@ -406,9 +406,9 @@ into a column number."
 
 "
 pub fn get_column_idx(header: [2][]const u8, column: []const u8) isize {
-    for (header) |col, i| {
-        if (std.mem.eql(u8, std.mem.span(col), std.mem.span(column))) {
-            return @intCast(isize, i);
+    for (header, 0..) |col, i| {
+        if (std.mem.eql(u8, col, column)) {
+            return @intCast(i);
         }
     }
     return -1;
@@ -431,7 +431,7 @@ specifying a variable with the name of the table."
      (format
       "
 pub fn %s_h (row: usize, col: []const u8) %s {
-    return %s[row][@intCast(usize, get_column_idx(%s_header,col))];
+    return %s[row][@intCast(get_column_idx(%s_header,col))];
 }
 "
       table zig-type table table))))

--- a/test-ob-zig-runner.el
+++ b/test-ob-zig-runner.el
@@ -18,13 +18,16 @@
 (defvar ob-zig-setup-location nil)
 
 (if load-in-progress
-    (setq ob-zig-setup-location (symbol-file 'ob-zig-setup-location))
+    (if (symbol-file 'ob-zig-setup-location) 
+        (setq ob-zig-setup-location (symbol-file 'ob-zig-setup-location)))
   (setq ob-zig-setup-location (buffer-file-name)))
 
 ;; Example from my doom-emacs setup
 ;; (add-to-list 'load-path (expand-file-name "straight/repos/org/testing" doom-local-dir))
 
-(defvar ob-zig-test-dir (file-name-directory ob-zig-setup-location))
+(defvar ob-zig-test-dir
+  (if ob-zig-setup-location
+      (file-name-directory ob-zig-setup-location)))
 
 (defun test-ob-zig-id-files ()
   (interactive)

--- a/test-ob-zig-runner.el
+++ b/test-ob-zig-runner.el
@@ -53,9 +53,10 @@
   (require 'ob-zig)
   (require 'test-ob-zig)
 
-  (org-babel-do-load-languages (and (mapc (lambda (lang) (add-to-list 'org-babel-load-languages (cons lang t)))
-                                          '(zig org))
-                                    org-babel-load-languages))
+  (add-to-list 'org-babel-load-languages '(org . t))
+  (add-to-list 'org-babel-load-languages '(zig . t))
+
+  (org-babel-do-load-languages 'org-babel-load-languages org-babel-load-languages)
   (test-ob-zig-update-id-locations))
 
 (defun test-ob-zig-run-tests ()

--- a/test-ob-zig-runner.el
+++ b/test-ob-zig-runner.el
@@ -53,9 +53,7 @@
   (require 'ob-zig)
   (require 'test-ob-zig)
 
-  (add-to-list 'org-babel-load-languages '(org . t))
   (add-to-list 'org-babel-load-languages '(zig . t))
-
   (org-babel-do-load-languages 'org-babel-load-languages org-babel-load-languages)
   (test-ob-zig-update-id-locations))
 

--- a/test-ob-zig.el
+++ b/test-ob-zig.el
@@ -59,6 +59,27 @@
         (org-babel-next-src-block 4)
         (should (equal "word 4" (org-babel-execute-src-block))))))
 
+(ert-deftest ob-zig/simple-zig-test ()
+  "Test of a string input variable"
+  (if (executable-find org-babel-zig-compiler)
+      (org-test-at-id "b1d3335f-8731-43b8-9246-6e613f3be3a2"
+        (org-babel-next-src-block 1)
+        (should (equal "hello" (org-babel-execute-src-block))))))
+
+(ert-deftest ob-zig/fn-zig-test ()
+  "Test of a string input variable"
+  (if (executable-find org-babel-zig-compiler)
+      (org-test-at-id "b1d3335f-8731-43b8-9246-6e613f3be3a2"
+        (org-babel-next-src-block 2)
+        (should (equal "hello" (org-babel-execute-src-block))))))
+
+(ert-deftest ob-zig/mutli-tests-zig-test ()
+  "Test of a string input variable"
+  (if (executable-find org-babel-zig-compiler)
+      (org-test-at-id "b1d3335f-8731-43b8-9246-6e613f3be3a2"
+        (org-babel-next-src-block 3)
+        (should (equal "hellohello" (org-babel-execute-src-block))))))
+
 (ert-deftest ob-zig/list-var ()
   "Test of a list input variable"
   (if (executable-find org-babel-zig-compiler)

--- a/test-ob-zig.el
+++ b/test-ob-zig.el
@@ -60,21 +60,21 @@
         (should (equal "word 4" (org-babel-execute-src-block))))))
 
 (ert-deftest ob-zig/simple-zig-test ()
-  "Test of a string input variable"
+  "Simple Zig test"
   (if (executable-find org-babel-zig-compiler)
       (org-test-at-id "b1d3335f-8731-43b8-9246-6e613f3be3a2"
         (org-babel-next-src-block 1)
         (should (equal "hello" (org-babel-execute-src-block))))))
 
 (ert-deftest ob-zig/fn-zig-test ()
-  "Test of a string input variable"
+  "Zig test with a function"
   (if (executable-find org-babel-zig-compiler)
       (org-test-at-id "b1d3335f-8731-43b8-9246-6e613f3be3a2"
         (org-babel-next-src-block 2)
         (should (equal "hello" (org-babel-execute-src-block))))))
 
 (ert-deftest ob-zig/mutli-tests-zig-test ()
-  "Test of a string input variable"
+  "Test with multiple test functions"
   (if (executable-find org-babel-zig-compiler)
       (org-test-at-id "b1d3335f-8731-43b8-9246-6e613f3be3a2"
         (org-babel-next-src-block 3)


### PR DESCRIPTION
# Add feature Zig test
Add tests in Zig with Org Babel.

Work performed:
- Code modification to add Zig tests.
- Add Org Babel tests to validate the new functionality.
- Revise Org Babel test scripts to accommodate Emacs 29.2.
- Adjust Zig code generation for tables to ensure compatibility with Zig versions 0.11 and 0.12.

Create an example with Zig tests:
```
#+begin_src zig :imports '(std) :testsuite 'yes
  test "Test ArrayList" {
      var array = std.ArrayList(i32).init(std.testing.allocator);
      defer array.deinit();

      const expected: i32 = 42;
      try array.append(expected);

      try std.testing.expectEqual(expected, array.items[0]);
  }
#+end_src
```
And a window will append to tell the number of tests passed when the source bloc is executed with `C-c C-c`.

When we set the option `:testsuite` to `'yes`, we will perform a `zig test` on the generated file. 
Also, the written code will not be wrapped by the main function.