### PR TITLE
feat: Add testsuite to org-babel-heaer-args:zig

### DIFF
--- a/ob-zig.el
+++ b/ob-zig.el
@@ -50,12 +50,13 @@
 ;; optionally declare default header arguments for this language
 (defvar org-babel-default-header-args:zig '())
 
-(defconst org-babel-header-args:zig '((includes . :any)
-                                      (imports . :any)
-                                      (main    . :any)
-                                      (flags   . :any)
-                                      (cmdline . :any)
-                                      (libs    . :any))
+(defconst org-babel-header-args:zig '((includes  . :any)
+                                      (imports   . :any)
+                                      (main      . :any)
+                                      (flags     . :any)
+                                      (cmdline   . :any)
+                                      (libs      . :any)
+                                      (testsuite . ((yes no))))
   "Zig-specific header arguments.")
 
 (defcustom org-babel-zig-compiler "zig"


### PR DESCRIPTION
Add `testsuite` to `org-babel-header-args:zig`.

This is a specific QOL improvement - I can use `org-babel-insert-header-arg` to quickly create org-babel blocks w/ `test` blocks.